### PR TITLE
Make sure the code really generates the PAGE_SIZE specified.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,4 +20,4 @@ DEPENDENCIES
   pry
 
 BUNDLED WITH
-   1.17.2
+   2.2.22

--- a/planner.rb
+++ b/planner.rb
@@ -29,7 +29,7 @@ FONTS = {
 }
 
 FILE_NAME = "time_block_pages.pdf"
-PAGE_SIZE = 'LETTER'
+PAGE_SIZE = 'A4'
 # Order is top, right, bottom, left
 LEFT_PAGE_MARGINS = [36, 72, 36, 36]
 RIGHT_PAGE_MARGINS = [36, 36, 36, 72]
@@ -454,7 +454,7 @@ def weekend_page saturday, sunday
   end
 end
 
-Prawn::Document.generate(FILE_NAME, margin: RIGHT_PAGE_MARGINS, print_scaling: :none) do
+Prawn::Document.generate(FILE_NAME, margin: RIGHT_PAGE_MARGINS, page_size: PAGE_SIZE, print_scaling: :none) do
   font_families.update(FONTS)
   font(FONTS.keys.first)
   stroke_color MEDIUM_COLOR


### PR DESCRIPTION
The line start_new_page size: PAGE_SIZE, layout: :portrait, margin: margin does indeed set the page size for a new page. However, the initial Prawn::Document.generate call determines the default settings for the entire document, including the page size for the first page.

If the start_new_page method is used later in the code (after the first page has already been created with the default settings), it will apply the PAGE_SIZE setting to the new pages added after the initial page. This means the first page would still be in the default size (LETTER), while subsequent pages would be in A4 size.

One way to tell the page size is with the pdfinfo command line.